### PR TITLE
Move binary to correct directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
 sudo chmod +x m
-sudo cp -v m /usr/bin/
-
-exit
+sudo cp -v m /usr/local/bin/


### PR DESCRIPTION
Everything not managed by a package manager belongs into /usr/local/*